### PR TITLE
Add coin rewards for defeating enemies

### DIFF
--- a/src/app/game-constants.ts
+++ b/src/app/game-constants.ts
@@ -26,11 +26,13 @@ interface GameConfig extends Config {
   >;
   killLevelFactor: number;
   collectableFactor: number;
+  killsPerCoin: number;
 }
 
 export const GAME_CONFIG: GameConfig = {
   killLevelFactor: 0.1,
   collectableFactor: 0.2,
+  killsPerCoin: 25,
   enemy: {
     autoSpawnSpeed: 0.35, // per second
     maxCount: 20,

--- a/src/app/services/game-screen.service.ts
+++ b/src/app/services/game-screen.service.ts
@@ -9,7 +9,7 @@ export class GameScreenService extends UpdatableService {
   readonly #ship = inject(GameShipService);
 
   private readonly points = new Text({ text: `0 ${icons.points}  `, style: fontAwesomeStyle });
-  private readonly coins = new Text({ text: `0 ${icons.coin}  `, style: fontAwesomeStyle });
+  private readonly coinLabel = new Text({ text: `0 ${icons.coin}  `, style: fontAwesomeStyle });
   private readonly levelLabel = new Text({ text: `1 ${icons.level}  `, style: fontAwesomeStyle });
 
   private lifesLabel: Graphics | undefined;
@@ -22,6 +22,11 @@ export class GameScreenService extends UpdatableService {
   set level(value: number) {
     this.levelLabel!.text = `${value} ${icons.level}  `;
     this.levelLabel!.x = this.application.screen.width - this.levelLabel!.width;
+  }
+
+  set coins(value: number) {
+    this.coinLabel!.text = `${value} ${icons.coin}  `;
+    this.coinLabel!.x = this.application.screen.width - this.coinLabel!.width;
   }
 
   private set lifes(value: number) {
@@ -53,9 +58,9 @@ export class GameScreenService extends UpdatableService {
     this.levelLabel.y = 45;
     this.addToStage(this.levelLabel);
 
-    this.coins.x = this.application.screen.width - this.coins.width;
-    this.coins.y = 30;
-    this.addToStage(this.coins);
+    this.coinLabel.x = this.application.screen.width - this.coinLabel.width;
+    this.coinLabel.y = 30;
+    this.addToStage(this.coinLabel);
   }
 
   update(): void {

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -23,6 +23,9 @@ import { UpdatableService } from './updatable.service';
 @Injectable()
 export class GameService {
   readonly kills = signal(0);
+  readonly coins = computed(() =>
+    Math.floor(this.kills() / Math.max(GAME_CONFIG.killsPerCoin, 1)),
+  );
 
   private readonly collectables = inject(GameCollectableService);
   private readonly landscape = inject(GameLandscapeService);
@@ -60,6 +63,7 @@ export class GameService {
 
       this.gameScreen.kills = this.kills();
       this.gameScreen.level = this.level();
+      this.gameScreen.coins = this.coins();
     });
 
     this.object.onDestroyed(ObjectType.enemy, (_, by) => {


### PR DESCRIPTION
## Summary
- add configuration to award coins based on the number of defeated enemies
- compute and update coin rewards during gameplay using existing signals
- adjust the HUD to keep the coin display aligned when the value changes

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dfea8af3e48324a2950550aae4e2bf