### PR TITLE
Use ChromeHeadlessCI as default Karma browser

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,10 +36,16 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false,
+    autoWatch: !process.env.CI,
+    browsers: ['ChromeHeadlessCI'],
+    singleRun: !!process.env.CI,
     restartOnFileChange: true,
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+      },
+    },
     failOnEmptyTestSuite: false
   });
 };


### PR DESCRIPTION
## Summary
- update Karma to always use the ChromeHeadlessCI launcher so local runs match CI

## Testing
- CI=1 npm test *(fails in container: Chrome binary unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dfedcc7dac8324a57b4798f0edc624