### PR TITLE
Persist coins between games

### DIFF
--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -23,9 +23,11 @@ import { UpdatableService } from './updatable.service';
 @Injectable()
 export class GameService {
   readonly kills = signal(0);
-  readonly coins = computed(() =>
+  readonly storedCoins = signal(0);
+  readonly sessionCoins = computed(() =>
     Math.floor(this.kills() / Math.max(GAME_CONFIG.killsPerCoin, 1)),
   );
+  readonly coins = computed(() => this.storedCoins() + this.sessionCoins());
 
   private readonly collectables = inject(GameCollectableService);
   private readonly landscape = inject(GameLandscapeService);
@@ -66,6 +68,10 @@ export class GameService {
       this.gameScreen.coins = this.coins();
     });
 
+    effect(() => {
+      void this.storage.setCoins(this.coins());
+    });
+
     this.object.onDestroyed(ObjectType.enemy, (_, by) => {
       if (by.type === ObjectType.ship || by.reference?.type === ObjectType.ship) {
         this.kills.update((value) => value + 1);
@@ -81,6 +87,9 @@ export class GameService {
     this.landscape.setup();
     this.gameScreen.init();
 
+    const storedCoins = await this.storage.getCoins();
+    this.storedCoins.set(storedCoins);
+
     this.setup();
 
     await this.presentPopup(NavigationPopup);
@@ -88,6 +97,9 @@ export class GameService {
 
   async start(requester: AppScreen): Promise<void> {
     await this.hideAndRemoveScreen(requester);
+    const storedCoins = await this.storage.getCoins();
+    this.storedCoins.set(storedCoins);
+    this.kills.set(0);
     this.started.set(true);
   }
 

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 export enum Store {
   games = 'games',
+  coins = 'coins',
 }
 
 @Injectable({ providedIn: 'root' })
@@ -10,7 +11,7 @@ export class StorageService {
     const data: T[] = Array.isArray(dataToStore) ? dataToStore : [dataToStore];
     return new Promise<void>((resolve, reject) => {
       // eslint-disable-next-line no-magic-numbers
-      const dbRequest = indexedDB.open('data', 4);
+      const dbRequest = indexedDB.open('data', 5);
       dbRequest.onerror = (): void => {
         reject(Error('IndexedDB database error'));
       };
@@ -55,6 +56,11 @@ export class StorageService {
 
       dbRequest.onsuccess = function (event: Event): void {
         const database = (event.currentTarget as IDBOpenDBRequest).result;
+        if (!database.objectStoreNames.contains(storeName)) {
+          resolve([]);
+          return;
+        }
+
         const store = database.transaction([storeName]).objectStore(storeName);
         const objectRequest = store.getAll();
 
@@ -82,7 +88,34 @@ export class StorageService {
     });
   }
 
+  async getCoins(): Promise<number> {
+    const entries = await this.getManyFromStore<{ id: string; amount: number }>(
+      Store.coins,
+      (item) => item.id === 'coins',
+    );
+    const entry = entries.at(0);
+
+    if (entry) {
+      return entry.amount;
+    }
+
+    return 0;
+  }
+
+  setCoins(amount: number): Promise<void> {
+    return this.toStore(Store.coins, {
+      id: 'coins',
+      amount,
+    });
+  }
+
   private migrateDatabase(database: IDBDatabase): void {
-    database.createObjectStore(Store.games, { keyPath: 'id' });
+    if (!database.objectStoreNames.contains(Store.games)) {
+      database.createObjectStore(Store.games, { keyPath: 'id' });
+    }
+
+    if (!database.objectStoreNames.contains(Store.coins)) {
+      database.createObjectStore(Store.coins, { keyPath: 'id' });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add an IndexedDB store and helper APIs to keep a persistent coin total
- load stored coins when starting a game and persist updated totals as coins change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dff2f4b2bc8324bfa5463a7451de1c