### PR TITLE
Display meteor energy on sprites

### DIFF
--- a/src/app/models/pixijs/simple-game-sprite.ts
+++ b/src/app/models/pixijs/simple-game-sprite.ts
@@ -8,22 +8,49 @@ export class GameSprite extends Sprite {
   power = 1;
   reference: ObjectModelType | undefined;
   destroying = false;
+
+  private _energy: number | undefined;
+
   private readonly ySpeed: number;
   private readonly xSpeed: number;
-  private _energy: number | undefined;
   private energyLabel: Text | undefined;
 
   constructor(
     readonly type: ObjectType,
     private readonly explosion: ExplosionService,
-    speed: number,
-    texture: Texture,
+    {
+      speed,
+      texture,
+      hasEnergy,
+    }: {
+      speed: number;
+      texture: Texture;
+      hasEnergy?: boolean;
+    },
   ) {
     super(texture);
 
     this.ySpeed = Math.random() * speed;
     // eslint-disable-next-line no-magic-numbers
     this.xSpeed = (Math.random() * speed) / 2;
+
+    if (hasEnergy) {
+      const energyLabel = new Text({
+        text: '',
+        style: {
+          fontFamily: 'Arial',
+          fontSize: 12,
+          fontWeight: 'bold',
+          fill: 0xffffff,
+          stroke: {
+            color: 0x000000,
+            width: 3,
+          },
+          align: 'center',
+        },
+      });
+      this.setEnergyLabel(energyLabel);
+    }
   }
 
   get energy(): number | undefined {
@@ -35,7 +62,7 @@ export class GameSprite extends Sprite {
     this.updateEnergyLabel();
   }
 
-  setEnergyLabel(label: Text): void {
+  private setEnergyLabel(label: Text): void {
     this.energyLabel = label;
     // eslint-disable-next-line no-magic-numbers
     this.energyLabel.anchor.set(0.5);

--- a/src/app/models/pixijs/simple-game-sprite.ts
+++ b/src/app/models/pixijs/simple-game-sprite.ts
@@ -1,4 +1,4 @@
-import { Sprite, Texture, Ticker } from 'pixi.js';
+import { Sprite, Text, Texture, Ticker } from 'pixi.js';
 import { ExplosionService } from '../../services/explosion.service';
 import { ObjectModelType } from '../../services/object.service';
 import { hit } from '../../utils/sprite.util';
@@ -7,10 +7,11 @@ import { ObjectType } from './object-type.enum';
 export class GameSprite extends Sprite {
   power = 1;
   reference: ObjectModelType | undefined;
-  energy: number | undefined;
   destroying = false;
   private readonly ySpeed: number;
   private readonly xSpeed: number;
+  private _energy: number | undefined;
+  private energyLabel: Text | undefined;
 
   constructor(
     readonly type: ObjectType,
@@ -23,6 +24,32 @@ export class GameSprite extends Sprite {
     this.ySpeed = Math.random() * speed;
     // eslint-disable-next-line no-magic-numbers
     this.xSpeed = (Math.random() * speed) / 2;
+  }
+
+  get energy(): number | undefined {
+    return this._energy;
+  }
+
+  set energy(value: number | undefined) {
+    this._energy = value;
+    this.updateEnergyLabel();
+  }
+
+  setEnergyLabel(label: Text): void {
+    this.energyLabel = label;
+    // eslint-disable-next-line no-magic-numbers
+    this.energyLabel.anchor.set(0.5);
+    this.energyLabel.position.set(0, 0);
+    this.addChild(this.energyLabel);
+    this.updateEnergyLabel();
+  }
+
+  private updateEnergyLabel(): void {
+    if (!this.energyLabel) {
+      return;
+    }
+    this.energyLabel.text = this._energy?.toString() ?? '';
+    this.energyLabel.visible = this._energy !== undefined;
   }
 
   update(ticker: Ticker): void {

--- a/src/app/services/game-meteor.service.ts
+++ b/src/app/services/game-meteor.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { Text, Texture, Ticker } from 'pixi.js';
+import { Texture, Ticker } from 'pixi.js';
 import { GAME_CONFIG } from '../game-constants';
 import { ObjectType } from '../models/pixijs/object-type.enum';
 import { GameSprite } from '../models/pixijs/simple-game-sprite';
@@ -41,13 +41,12 @@ export class GameMeteorService extends UpdatableService {
     const position = Math.floor(Math.random() * this.application.screen.width - 20) + 10;
     // eslint-disable-next-line no-magic-numbers
     const index = Math.floor(Math.random() * 4) + 1;
-    const meteor = new GameSprite(
-      ObjectType.meteor,
-      this.explosionService,
+    const meteor = new GameSprite(ObjectType.meteor, this.explosionService, {
       // eslint-disable-next-line no-magic-numbers
-      0.1 + 0.125 * level,
-      Texture.from(`meteor${index}`),
-    );
+      speed: 0.1 + 0.125 * level,
+      texture: Texture.from(`meteor${index}`),
+      hasEnergy: true,
+    });
     // eslint-disable-next-line no-magic-numbers
     meteor.anchor.set(0.5);
     meteor.x = position;
@@ -57,21 +56,6 @@ export class GameMeteorService extends UpdatableService {
     // eslint-disable-next-line no-magic-numbers
     meteor.height += Math.random() * 20;
     meteor.energy = 10;
-    const energyLabel = new Text({
-      text: '',
-      style: {
-        fontFamily: 'Arial',
-        fontSize: 12,
-        fontWeight: 'bold',
-        fill: 0xffffff,
-        stroke: {
-          color: 0x000000,
-          width: 3,
-        },
-        align: 'center',
-      },
-    });
-    meteor.setEnergyLabel(energyLabel);
     this.object.add(meteor);
     this.application.stage.addChild(meteor);
   }

--- a/src/app/services/game-meteor.service.ts
+++ b/src/app/services/game-meteor.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { Texture, Ticker } from 'pixi.js';
+import { Text, Texture, Ticker } from 'pixi.js';
 import { GAME_CONFIG } from '../game-constants';
 import { ObjectType } from '../models/pixijs/object-type.enum';
 import { GameSprite } from '../models/pixijs/simple-game-sprite';
@@ -57,6 +57,21 @@ export class GameMeteorService extends UpdatableService {
     // eslint-disable-next-line no-magic-numbers
     meteor.height += Math.random() * 20;
     meteor.energy = 10;
+    const energyLabel = new Text({
+      text: '',
+      style: {
+        fontFamily: 'Arial',
+        fontSize: 12,
+        fontWeight: 'bold',
+        fill: 0xffffff,
+        stroke: {
+          color: 0x000000,
+          width: 3,
+        },
+        align: 'center',
+      },
+    });
+    meteor.setEnergyLabel(energyLabel);
     this.object.add(meteor);
     this.application.stage.addChild(meteor);
   }


### PR DESCRIPTION
## Summary
- add support for optional energy labels to generic game sprites
- render each meteor's remaining energy centered on the meteor sprite

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e008260070832480d9027a5c72081d