### PR TITLE
Slow down meteors

### DIFF
--- a/src/app/services/game-meteor.service.ts
+++ b/src/app/services/game-meteor.service.ts
@@ -43,7 +43,7 @@ export class GameMeteorService extends UpdatableService {
     const index = Math.floor(Math.random() * 4) + 1;
     const meteor = new GameSprite(ObjectType.meteor, this.explosionService, {
       // eslint-disable-next-line no-magic-numbers
-      speed: 0.1 + 0.125 * level,
+      speed: 0.08 + 0.1 * level,
       texture: Texture.from(`meteor${index}`),
       hasEnergy: true,
     });


### PR DESCRIPTION
## Summary
- reduce the base and per-level speed applied to spawned meteors so they move more slowly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02bf6d9688324a4ce61a82a90078c