### PR TITLE
Adjust meteor energy scaling

### DIFF
--- a/src/app/services/game-meteor.service.ts
+++ b/src/app/services/game-meteor.service.ts
@@ -55,7 +55,9 @@ export class GameMeteorService extends UpdatableService {
     meteor.width += Math.random() * 20;
     // eslint-disable-next-line no-magic-numbers
     meteor.height += Math.random() * 20;
-    meteor.energy = 10;
+    const baseEnergy = 10;
+    // Increase energy by 5 for each additional level while keeping a minimum of 10
+    meteor.energy = Math.max(baseEnergy, baseEnergy + 5 * (level - 1));
     this.object.add(meteor);
     this.application.stage.addChild(meteor);
   }


### PR DESCRIPTION
## Summary
- scale meteor energy based on the current level while keeping a minimum of 10

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02c32ea748324b10205f0d7922a4c