### PR TITLE
Optimize object service update loop

### DIFF
--- a/src/app/services/game-meteor.service.ts
+++ b/src/app/services/game-meteor.service.ts
@@ -7,6 +7,8 @@ import { ExplosionService } from './explosion.service';
 import { ObjectService } from './object.service';
 import { UpdatableService } from './updatable.service';
 
+const METEOR_ENERGY_STEP = 5;
+
 @Injectable()
 export class GameMeteorService extends UpdatableService {
   private readonly explosionService = inject(ExplosionService);
@@ -56,8 +58,8 @@ export class GameMeteorService extends UpdatableService {
     // eslint-disable-next-line no-magic-numbers
     meteor.height += Math.random() * 20;
     const baseEnergy = 10;
-    // Increase energy by 5 for each additional level while keeping a minimum of 10
-    meteor.energy = Math.max(baseEnergy, baseEnergy + 5 * (level - 1));
+    // Increase energy by METEOR_ENERGY_STEP for each additional level while keeping a minimum of 10
+    meteor.energy = Math.max(baseEnergy, baseEnergy + METEOR_ENERGY_STEP * (level - 1));
     this.object.add(meteor);
     this.application.stage.addChild(meteor);
   }

--- a/src/app/services/object.service.ts
+++ b/src/app/services/object.service.ts
@@ -29,39 +29,48 @@ export class ObjectService extends UpdatableService {
   }
 
   update(ticker: Ticker): void {
-    this.#objects.update((objects) =>
-      objects.filter((object) => !object.destroyed && !object.destroying),
-    );
+    const objects = this.#objects();
 
-    this.meteors().forEach((object) => object.update(ticker));
-
-    const objectsList = this.#objects();
-    for (let i = 0; i < objectsList.length; i++) {
-      const object1 = objectsList[i];
-      if (object1.destroyed && object1.destroying) {
-        return;
+    for (let i = 0; i < objects.length; i++) {
+      const object = objects[i];
+      if (object.destroyed || object.destroying || object.type !== ObjectType.meteor) {
+        continue;
       }
-      for (let j = 0; j < objectsList.length; j++) {
-        const object2 = objectsList[j];
+      object.update(ticker);
+    }
+
+    for (let i = 0; i < objects.length; i++) {
+      const object1 = objects[i];
+      if (object1.destroyed || object1.destroying) {
+        continue;
+      }
+
+      for (let j = i + 1; j < objects.length; j++) {
+        const object2 = objects[j];
+
         if (
           object1 === object2 ||
           object2.destroyed ||
           object2.destroying ||
-          object1.destroyed ||
-          object1.destroying ||
           !object1.hit(object2)
         ) {
           continue;
         }
+
         this.triggerCallbacks(object1, object2);
         this.triggerCallbacks(object2, object1);
       }
     }
 
-    this.#objects()
-      .filter((item) => item.destroying)
-      .forEach((item) => item.destroy());
-    this.#objects.update((objects) => objects.filter((object) => !object.destroyed));
+    for (let i = 0; i < objects.length; i++) {
+      const object = objects[i];
+      if (!object.destroying) {
+        continue;
+      }
+      object.destroy();
+    }
+
+    this.#objects.set(objects.filter((object) => !object.destroyed));
   }
 
   add(object: AnimatedGameSprite | GameSprite): void {


### PR DESCRIPTION
## Summary
- replace repeated signal filtering in the object service with cached collections and pairwise iteration that avoids redundant comparisons
- ensure objects flagged for destruction call their cleanup before pruning to keep memory stable
- introduce a named constant for meteor energy scaling instead of a magic number

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0401edb1883249ca7dd0629187afc