### PR TITLE
Make collectables collectable by the ship

### DIFF
--- a/src/app/models/pixijs/power-up-sprite.ts
+++ b/src/app/models/pixijs/power-up-sprite.ts
@@ -16,7 +16,7 @@ export class PowerUpSprite extends AnimatedGameSprite {
     super(ObjectType.collectable, null, speed, textures);
 
     this.config = config;
-    this.energy = 20;
+    this.energy = 1;
   }
 
   override explode(): void {


### PR DESCRIPTION
## Summary
- lower the durability of power-up sprites so they are destroyed on the first touch by the ship, triggering the collect logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0ba0546288324be1fa0c9c3bb63ec