### PR TITLE
Randomize enemy speed scaling by level

### DIFF
--- a/src/app/services/game-enemy.service.ts
+++ b/src/app/services/game-enemy.service.ts
@@ -51,12 +51,16 @@ export class GameEnemyService extends UpdatableService {
 
   private spawn(level: number): void {
     const animations: Record<string, Texture[]> = this.enemySprite.animations;
+    // eslint-disable-next-line no-magic-numbers
+    const maxSpeed = 0.4 + 0.025 * level;
+    // eslint-disable-next-line no-magic-numbers
+    const speedVariation = 0.6 + Math.random() * 0.4;
+
     const enemy = new Ship(
       ShipType.enemy,
       this.shotService,
       this.explosionService,
-      // eslint-disable-next-line no-magic-numbers
-      0.4 + 0.025 * level,
+      maxSpeed * speedVariation,
       animations['frame'],
     );
     enemy.autoFire = true;


### PR DESCRIPTION
## Summary
- randomize the vertical speed of spawned enemies so that they vary per spawn
- keep the maximum enemy speed level-dependent while introducing per-spawn variation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1a0aa79188324bf1245a2e9afe87a