### PR TITLE
Extract standalone helper functions for service utilities

### DIFF
--- a/src/app/services/game-collectable.service.ts
+++ b/src/app/services/game-collectable.service.ts
@@ -11,6 +11,17 @@ interface Dictionary<T> {
   [key: string]: T;
 }
 
+function collectPowerUp(object: ObjectModelType, by: ObjectModelType): void {
+  if (by.type !== ObjectType.ship) {
+    return;
+  }
+  const ship = by as unknown as Ship;
+  const powerUp = object as unknown as PowerUpSprite;
+  ship.shotSpeed += powerUp.config.powerUp.speed;
+  ship.shotPower += powerUp.config.powerUp.shot;
+  ship.energy += powerUp.config.powerUp.energy;
+}
+
 @Injectable()
 export class GameCollectableService extends UpdatableService {
   private readonly object = inject(ObjectService);
@@ -21,7 +32,7 @@ export class GameCollectableService extends UpdatableService {
     super();
 
     this.object.onDestroyed(ObjectType.enemy, (enemy, by) => this.spawn(enemy, by));
-    this.object.onDestroyed(ObjectType.collectable, (powerUp, by) => this.collect(powerUp, by));
+    this.object.onDestroyed(ObjectType.collectable, (powerUp, by) => collectPowerUp(powerUp, by));
   }
 
   async init(): Promise<void> {
@@ -32,17 +43,6 @@ export class GameCollectableService extends UpdatableService {
         this.animations[config.type] = animations[config.animationName];
       }
     }
-  }
-
-  collect(object: ObjectModelType, by: ObjectModelType): void {
-    if (by.type !== ObjectType.ship) {
-      return;
-    }
-    const ship = by as unknown as Ship;
-    const powerUp = object as unknown as PowerUpSprite;
-    ship.shotSpeed += powerUp.config.powerUp.speed;
-    ship.shotPower += powerUp.config.powerUp.shot;
-    ship.energy += powerUp.config.powerUp.energy;
   }
 
   update(): void {

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -25,6 +25,16 @@ import { UpdatableService } from './updatable.service';
 
 const METEOR_COIN_ENERGY_STEP = 20;
 
+function isShipDestroyer(by: ObjectModelType): boolean {
+  return by.type === ObjectType.ship || by.reference?.type === ObjectType.ship;
+}
+
+function calculateMeteorCoins(meteor: ObjectModelType): number {
+  const energy = meteor.initialEnergy ?? meteor.energy ?? 0;
+
+  return Math.floor(energy / METEOR_COIN_ENERGY_STEP);
+}
+
 @Injectable()
 export class GameService {
   readonly kills = signal(0);
@@ -84,11 +94,11 @@ export class GameService {
     });
 
     this.object.onDestroyed(ObjectType.meteor, (meteor, by) => {
-      if (!this.started() || !this.isShipDestroyer(by)) {
+      if (!this.started() || !isShipDestroyer(by)) {
         return;
       }
 
-      const coins = this.calculateMeteorCoins(meteor);
+      const coins = calculateMeteorCoins(meteor);
 
       if (coins <= 0 || this.rewardedMeteors.has(meteor)) {
         return;
@@ -283,13 +293,4 @@ export class GameService {
     this.sessionCoins.set(Math.max(0, sessionCoins - remainingCost));
   }
 
-  private isShipDestroyer(by: ObjectModelType): boolean {
-    return by.type === ObjectType.ship || by.reference?.type === ObjectType.ship;
-  }
-
-  private calculateMeteorCoins(meteor: ObjectModelType): number {
-    const energy = meteor.initialEnergy ?? meteor.energy ?? 0;
-
-    return Math.floor(energy / METEOR_COIN_ENERGY_STEP);
-  }
 }

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -6,6 +6,42 @@ export enum Store {
   upgrades = 'upgrades',
 }
 
+function getManyFromStore<T>(
+  storeName: Store,
+  resolver?: (item: T) => boolean,
+): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    const dbRequest = indexedDB.open('data');
+    dbRequest.onerror = function (): void {
+      resolve([]);
+    };
+
+    dbRequest.onupgradeneeded = function (event: IDBVersionChangeEvent): void {
+      (event.currentTarget as IDBOpenDBRequest).transaction?.abort();
+      resolve([]);
+    };
+
+    dbRequest.onsuccess = function (event: Event): void {
+      const database = (event.currentTarget as IDBOpenDBRequest).result;
+      if (!database.objectStoreNames.contains(storeName)) {
+        resolve([]);
+        return;
+      }
+
+      const store = database.transaction([storeName]).objectStore(storeName);
+      const objectRequest = store.getAll();
+
+      objectRequest.onerror = function (): void {
+        reject(Error('Error text'));
+      };
+
+      objectRequest.onsuccess = function (): void {
+        resolve((objectRequest.result as T[]).filter((item) => !resolver || resolver(item)));
+      };
+    };
+  });
+}
+
 @Injectable({ providedIn: 'root' })
 export class StorageService {
   toStore<T>(storeName: string, dataToStore: T | T[], clear = false): Promise<void> {
@@ -43,41 +79,8 @@ export class StorageService {
     });
   }
 
-  getManyFromStore<T>(storeName: Store, resolver?: (item: T) => boolean): Promise<T[]> {
-    return new Promise((resolve, reject) => {
-      const dbRequest = indexedDB.open('data');
-      dbRequest.onerror = function (): void {
-        resolve([]);
-      };
-
-      dbRequest.onupgradeneeded = function (event: IDBVersionChangeEvent): void {
-        (event.currentTarget as IDBOpenDBRequest).transaction?.abort();
-        resolve([]);
-      };
-
-      dbRequest.onsuccess = function (event: Event): void {
-        const database = (event.currentTarget as IDBOpenDBRequest).result;
-        if (!database.objectStoreNames.contains(storeName)) {
-          resolve([]);
-          return;
-        }
-
-        const store = database.transaction([storeName]).objectStore(storeName);
-        const objectRequest = store.getAll();
-
-        objectRequest.onerror = function (): void {
-          reject(Error('Error text'));
-        };
-
-        objectRequest.onsuccess = function (): void {
-          resolve((objectRequest.result as T[]).filter((item) => !resolver || resolver(item)));
-        };
-      };
-    });
-  }
-
   getHighscore(): Promise<{ date: string; kills: number; level: number }[]> {
-    return this.getManyFromStore(Store.games, () => true);
+    return getManyFromStore(Store.games, () => true);
   }
 
   setHighscore(kills: number, level: number): Promise<void> {
@@ -90,7 +93,7 @@ export class StorageService {
   }
 
   async getCoins(): Promise<number> {
-    const entries = await this.getManyFromStore<{ id: string; amount: number }>(
+    const entries = await getManyFromStore<{ id: string; amount: number }>(
       Store.coins,
       (item) => item.id === 'coins',
     );
@@ -111,7 +114,7 @@ export class StorageService {
   }
 
   async getShipUpgrades(): Promise<Record<string, number>> {
-    const entries = await this.getManyFromStore<{ id: string; levels: Record<string, number> }>(
+    const entries = await getManyFromStore<{ id: string; levels: Record<string, number> }>(
       Store.upgrades,
       (item) => item.id === 'ship-upgrades',
     );


### PR DESCRIPTION
## Summary
- move the generic IndexedDB retrieval logic into a standalone helper used by `StorageService`
- extract ship destroyer and meteor coin calculations in `GameService` into module-level functions
- refactor the collectable handling in `GameCollectableService` to rely on a standalone power-up helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23ab6c1a0832485f52dc63b2fd2a5