### PR TITLE
Show session coin count on death popup

### DIFF
--- a/src/app/game-constants.ts
+++ b/src/app/game-constants.ts
@@ -3,6 +3,7 @@ import { ShipType } from './models/pixijs/ship-type.enum';
 import { PowerUpConfig } from './models/power-up-config.model';
 
 export const THE_MIDDLE = 0.5;
+export const LARGE_POP_UP_HEIGHT = 420;
 
 interface Config {
   powerUpConfig: PowerUpConfig[];

--- a/src/app/popups/your-are-dead-popup.ts
+++ b/src/app/popups/your-are-dead-popup.ts
@@ -1,9 +1,10 @@
+import { LARGE_POP_UP_HEIGHT } from '../game-constants';
 import { GameService } from '../services/game.service';
 import { Popup } from './popup';
 
 export class YouAreDeadPopup extends Popup {
   constructor(gameService: GameService) {
-    super('Credits');
+    super('Credits', LARGE_POP_UP_HEIGHT);
 
     this.addText('Du bist gestorben', { size: 14 }, { y: -60 });
     this.addText(

--- a/src/app/popups/your-are-dead-popup.ts
+++ b/src/app/popups/your-are-dead-popup.ts
@@ -13,8 +13,10 @@ export class YouAreDeadPopup extends Popup {
     );
     this.addText('Punkte', { size: 14 }, { y: -10 });
     this.addText(gameService.kills().toString(), { size: 12 }, { y: 10 });
+    this.addText('Münzen in dieser Session', { size: 14 }, { y: 40 });
+    this.addText(gameService.sessionCoins().toString(), { size: 12 }, { y: 60 });
 
     // eslint-disable-next-line no-magic-numbers
-    this.addButton('Schließen!', () => gameService.endGame(this), 2);
+    this.addButton('Schließen!', () => gameService.endGame(this), 3);
   }
 }


### PR DESCRIPTION
## Summary
- show the number of coins earned during the current session in the death popup
- move the close button down to keep spacing after adding the new text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e399a485e08324acb45647d1e864b8