### PR TITLE
Restrict ship movement until game start

### DIFF
--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -187,9 +187,13 @@ export class GameService {
     this.application.stage.hitArea = this.application.screen;
     this.application.stage.on('pointerdown', () => (ship.instance.autoFire = true));
     this.application.stage.on('pointerup', () => (ship.instance.autoFire = false));
-    this.application.stage.on('pointermove', (event: FederatedPointerEvent) =>
-      handleMouseMove(event, ship.instance),
-    );
+    this.application.stage.on('pointermove', (event: FederatedPointerEvent) => {
+      if (!this.started()) {
+        return;
+      }
+
+      handleMouseMove(event, ship.instance);
+    });
   }
 
   private async presentPopup(ctor: AppScreenConstructor): Promise<void> {


### PR DESCRIPTION
## Summary
- gate pointer-based ship movement behind the started flag so the ship stays stationary before the game begins

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e9fa2e5b0883248952ff28d5814468