### PR TITLE
Prevent firing before game start

### DIFF
--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -134,6 +134,7 @@ export class GameService {
     this.sessionCoins.set(0);
     this.ship.applyUpgrades();
     this.kills.set(0);
+    this.ship.instance.autoFire = false;
     this.started.set(true);
   }
 
@@ -177,6 +178,7 @@ export class GameService {
       if (this.ship.instance.energy === 0) {
         void this.storage.setHighscore(this.kills(), this.level());
         void this.presentPopup(YouAreDeadPopup);
+        this.ship.instance.autoFire = false;
         this.started.set(false);
       }
     });
@@ -185,7 +187,13 @@ export class GameService {
   private setupInteractions(ship: GameShipService): void {
     this.application.stage.eventMode = 'dynamic';
     this.application.stage.hitArea = this.application.screen;
-    this.application.stage.on('pointerdown', () => (ship.instance.autoFire = true));
+    this.application.stage.on('pointerdown', () => {
+      if (!this.started()) {
+        return;
+      }
+
+      ship.instance.autoFire = true;
+    });
     this.application.stage.on('pointerup', () => (ship.instance.autoFire = false));
     this.application.stage.on('pointermove', (event: FederatedPointerEvent) =>
       handleMouseMove(event, ship.instance),


### PR DESCRIPTION
## Summary
- guard the pointer-down auto-fire handler behind the game start signal
- reset the ship auto-fire flag when starting a run or after the player dies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e9fa3b04f883249ba5da601315aef7