### PR TITLE
Adjust HUD header spacing

### DIFF
--- a/src/app/services/game-screen.service.ts
+++ b/src/app/services/game-screen.service.ts
@@ -7,6 +7,8 @@ import { UpdatableService } from './updatable.service';
 const HEADER_TOP_PADDING = 20;
 const HEADER_LINE_SPACING = 22;
 const HEADER_SIDE_PADDING = 8;
+const DOUBLE = 2;
+const TRIPPLE = 3;
 
 @Injectable()
 export class GameScreenService extends UpdatableService {
@@ -40,7 +42,7 @@ export class GameScreenService extends UpdatableService {
 
   init(): void {
     this.points.x = HEADER_SIDE_PADDING;
-    this.points.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * 3;
+    this.points.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * TRIPPLE;
     this.addToStage(this.points);
 
     const energyBarContainer = new Container();
@@ -55,7 +57,7 @@ export class GameScreenService extends UpdatableService {
     this.addToStage(energyBarContainer);
 
     this.lifesLabel.x = HEADER_SIDE_PADDING;
-    this.lifesLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * 2;
+    this.lifesLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * DOUBLE;
     this.addToStage(this.lifesLabel);
 
     this.levelLabel.x = this.application.screen.width - this.levelLabel.width;

--- a/src/app/services/game-screen.service.ts
+++ b/src/app/services/game-screen.service.ts
@@ -60,11 +60,11 @@ export class GameScreenService extends UpdatableService {
     this.lifesLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * DOUBLE;
     this.addToStage(this.lifesLabel);
 
-    this.levelLabel.x = this.application.screen.width - this.levelLabel.width;
+    this.levelLabel.x = this.application.screen.width - this.levelLabel.width - HEADER_SIDE_PADDING;
     this.levelLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING;
     this.addToStage(this.levelLabel);
 
-    this.coinLabel.x = this.application.screen.width - this.coinLabel.width;
+    this.coinLabel.x = this.application.screen.width - this.coinLabel.width - HEADER_SIDE_PADDING;
     this.coinLabel.y = HEADER_TOP_PADDING;
     this.addToStage(this.coinLabel);
   }

--- a/src/app/services/game-screen.service.ts
+++ b/src/app/services/game-screen.service.ts
@@ -4,6 +4,10 @@ import { fontAwesomeStyle, icons } from '../style-constants';
 import { GameShipService } from './game-ship.service';
 import { UpdatableService } from './updatable.service';
 
+const HEADER_TOP_PADDING = 20;
+const HEADER_LINE_SPACING = 22;
+const HEADER_SIDE_PADDING = 8;
+
 @Injectable()
 export class GameScreenService extends UpdatableService {
   readonly #ship = inject(GameShipService);
@@ -35,8 +39,8 @@ export class GameScreenService extends UpdatableService {
   }
 
   init(): void {
-    this.points.x = 5;
-    this.points.y = 65;
+    this.points.x = HEADER_SIDE_PADDING;
+    this.points.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * 3;
     this.addToStage(this.points);
 
     const energyBarContainer = new Container();
@@ -50,16 +54,16 @@ export class GameScreenService extends UpdatableService {
 
     this.addToStage(energyBarContainer);
 
-    this.lifesLabel.x = 5;
-    this.lifesLabel.y = 55;
+    this.lifesLabel.x = HEADER_SIDE_PADDING;
+    this.lifesLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * 2;
     this.addToStage(this.lifesLabel);
 
     this.levelLabel.x = this.application.screen.width - this.levelLabel.width;
-    this.levelLabel.y = 45;
+    this.levelLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING;
     this.addToStage(this.levelLabel);
 
     this.coinLabel.x = this.application.screen.width - this.coinLabel.width;
-    this.coinLabel.y = 30;
+    this.coinLabel.y = HEADER_TOP_PADDING;
     this.addToStage(this.coinLabel);
   }
 


### PR DESCRIPTION
## Summary
- introduce reusable header spacing constants for the HUD labels
- reposition score, energy, coin, and level labels with larger spacing for readability on different screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9fa5e878083248917cfbd899683be