### PR TITLE
feat: add dynamic enemy movement paths

### DIFF
--- a/src/app/models/pixijs/animated-game-sprite.ts
+++ b/src/app/models/pixijs/animated-game-sprite.ts
@@ -9,6 +9,7 @@ export class AnimatedGameSprite extends AnimatedSprite {
   reference: ObjectModelType | undefined;
   destroying = false;
   targetX?: number;
+  xSpeed: number = 1;
 
   protected readonly speed: number = 1;
   private _initialEnergy: number | undefined;
@@ -72,6 +73,6 @@ export class AnimatedGameSprite extends AnimatedSprite {
     // eslint-disable-next-line no-magic-numbers
     const speed = distance / 2;
     // eslint-disable-next-line no-magic-numbers
-    return Math.min(speed, 5);
+    return Math.min(speed, 5) * this.xSpeed;
   }
 }

--- a/src/app/models/pixijs/simple-game-sprite.ts
+++ b/src/app/models/pixijs/simple-game-sprite.ts
@@ -8,6 +8,7 @@ export class GameSprite extends Container {
   power = 1;
   reference: ObjectModelType | undefined;
   destroying = false;
+  targetX?: number;
 
   private _energy: number | undefined;
   private initialEnergyValue: number | undefined;

--- a/src/app/services/game-enemy.service.ts
+++ b/src/app/services/game-enemy.service.ts
@@ -97,6 +97,7 @@ export class GameEnemyService extends UpdatableService {
     enemy.anchor.set(THE_MIDDLE);
     enemy.x = Math.floor(Math.random() * this.application.screen.width - width) + halfWidth;
     enemy.y = 0;
+    enemy.xSpeed = 0.05;
     this.object.add(enemy);
     this.application.stage.addChild(enemy);
 

--- a/src/app/services/game-enemy.service.ts
+++ b/src/app/services/game-enemy.service.ts
@@ -10,6 +10,30 @@ import { UpdatableService } from './updatable.service';
 
 const halfWidth = 10;
 const width = halfWidth + halfWidth;
+const MOVEMENT_TARGET_SNAP_DISTANCE = 5;
+const MOVEMENT_MIN_DISTANCE_RATIO = 0.08;
+const MOVEMENT_MIN_DISTANCE_PIXELS = 40;
+const MOVEMENT_MAX_DISTANCE_RATIO = 0.22;
+const MOVEMENT_MAX_DISTANCE_PIXELS = 110;
+// eslint-disable-next-line no-magic-numbers
+const MOVEMENT_REVERSE_DIRECTION_MULTIPLIER = -1;
+const MOVEMENT_DIRECTIONS = Object.freeze(
+  [
+    MOVEMENT_REVERSE_DIRECTION_MULTIPLIER,
+    Math.abs(MOVEMENT_REVERSE_DIRECTION_MULTIPLIER),
+  ] as const,
+);
+const MOVEMENT_BASE_DELAY = 650;
+const MOVEMENT_RANDOM_DELAY_MIN = 450;
+const MOVEMENT_RANDOM_DELAY_RANGE = 400;
+const MOVEMENT_LEVEL_ACCELERATION = 25;
+const MOVEMENT_LEVEL_ACCELERATION_CAP = 10;
+const MOVEMENT_MIN_DELAY = 350;
+
+interface EnemyMovementState {
+  nextChange: number;
+  targetX?: number;
+}
 
 @Injectable()
 export class GameEnemyService extends UpdatableService {
@@ -21,6 +45,7 @@ export class GameEnemyService extends UpdatableService {
   private lastEnemySpawn: number | null = null;
 
   private enemySprite!: Spritesheet;
+  private readonly movementStates = new WeakMap<Ship, EnemyMovementState>();
 
   async init(): Promise<void> {
     this.enemySprite = await Assets.load<Spritesheet>('assets/game/enemies/enemy.json');
@@ -29,13 +54,18 @@ export class GameEnemyService extends UpdatableService {
   update(ticker: Ticker, level: number): void {
     this.elapsed += ticker.deltaMS;
 
-    this.object
-      .enemies()
+    const enemies = this.object.enemies();
+
+    enemies
       // eslint-disable-next-line no-magic-numbers
       .filter((enemy) => enemy.y > this.application.screen.height + 50)
       .forEach((enemy) => {
         enemy.y = 0;
+        enemy.targetX = undefined;
+        this.movementStates.delete(enemy);
       });
+
+    enemies.forEach((enemy) => this.updateMovement(enemy, level));
 
     const check = Math.floor(this.elapsed);
     if (
@@ -71,5 +101,63 @@ export class GameEnemyService extends UpdatableService {
     enemy.y = 0;
     this.object.add(enemy);
     this.application.stage.addChild(enemy);
+
+    this.updateMovement(enemy, level, true);
+  }
+
+  private updateMovement(enemy: Ship, level: number, force = false): void {
+    const screenWidth = this.application.screen.width;
+    const movement = this.getMovementState(enemy);
+
+    const shouldPickNewTarget =
+      force ||
+      movement.nextChange <= this.elapsed ||
+      movement.targetX === undefined ||
+      Math.abs((movement.targetX ?? enemy.x) - enemy.x) < MOVEMENT_TARGET_SNAP_DISTANCE;
+
+    if (shouldPickNewTarget) {
+      movement.targetX = this.getNextHorizontalTarget(enemy.x, screenWidth);
+      movement.nextChange = this.elapsed + this.getNextChangeDelay(level);
+    }
+
+    if (movement.targetX !== undefined) {
+      enemy.targetX = movement.targetX;
+    }
+  }
+
+  private getMovementState(enemy: Ship): EnemyMovementState {
+    if (!this.movementStates.has(enemy)) {
+      this.movementStates.set(enemy, { nextChange: 0 });
+    }
+    // Non-null assertion safe: we just set it when missing.
+    return this.movementStates.get(enemy)!;
+  }
+
+  private getNextHorizontalTarget(currentX: number, screenWidth: number): number {
+    const minDistance = Math.max(screenWidth * MOVEMENT_MIN_DISTANCE_RATIO, MOVEMENT_MIN_DISTANCE_PIXELS);
+    const maxDistance = Math.max(screenWidth * MOVEMENT_MAX_DISTANCE_RATIO, MOVEMENT_MAX_DISTANCE_PIXELS);
+    const preferredDirection =
+      MOVEMENT_DIRECTIONS[Math.floor(Math.random() * MOVEMENT_DIRECTIONS.length)];
+    const travelDistance = minDistance + Math.random() * (maxDistance - minDistance);
+
+    let candidate = currentX + preferredDirection * travelDistance;
+    const minX = halfWidth;
+    const maxX = screenWidth - halfWidth;
+
+    if (candidate < minX || candidate > maxX) {
+      candidate = currentX + preferredDirection * MOVEMENT_REVERSE_DIRECTION_MULTIPLIER * travelDistance;
+    }
+
+    candidate = Math.min(maxX, Math.max(minX, candidate));
+
+    return candidate;
+  }
+
+  private getNextChangeDelay(level: number): number {
+    const randomDelay = MOVEMENT_RANDOM_DELAY_MIN + Math.random() * MOVEMENT_RANDOM_DELAY_RANGE;
+    const levelAcceleration =
+      Math.min(Math.max(level - 1, 0), MOVEMENT_LEVEL_ACCELERATION_CAP) * MOVEMENT_LEVEL_ACCELERATION;
+
+    return Math.max(MOVEMENT_MIN_DELAY, MOVEMENT_BASE_DELAY + randomDelay - levelAcceleration);
   }
 }

--- a/src/app/services/game-enemy.service.ts
+++ b/src/app/services/game-enemy.service.ts
@@ -5,7 +5,7 @@ import { Ship } from '../models/pixijs/ship';
 import { ShipType } from '../models/pixijs/ship-type.enum';
 import { ExplosionService } from './explosion.service';
 import { GameShotService } from './game-shot.service';
-import { ObjectService } from './object.service';
+import { ObjectModelType, ObjectService } from './object.service';
 import { UpdatableService } from './updatable.service';
 
 const halfWidth = 10;
@@ -17,12 +17,10 @@ const MOVEMENT_MAX_DISTANCE_RATIO = 0.22;
 const MOVEMENT_MAX_DISTANCE_PIXELS = 110;
 // eslint-disable-next-line no-magic-numbers
 const MOVEMENT_REVERSE_DIRECTION_MULTIPLIER = -1;
-const MOVEMENT_DIRECTIONS = Object.freeze(
-  [
-    MOVEMENT_REVERSE_DIRECTION_MULTIPLIER,
-    Math.abs(MOVEMENT_REVERSE_DIRECTION_MULTIPLIER),
-  ] as const,
-);
+const MOVEMENT_DIRECTIONS = Object.freeze([
+  MOVEMENT_REVERSE_DIRECTION_MULTIPLIER,
+  Math.abs(MOVEMENT_REVERSE_DIRECTION_MULTIPLIER),
+] as const);
 const MOVEMENT_BASE_DELAY = 650;
 const MOVEMENT_RANDOM_DELAY_MIN = 450;
 const MOVEMENT_RANDOM_DELAY_RANGE = 400;
@@ -45,7 +43,7 @@ export class GameEnemyService extends UpdatableService {
   private lastEnemySpawn: number | null = null;
 
   private enemySprite!: Spritesheet;
-  private readonly movementStates = new WeakMap<Ship, EnemyMovementState>();
+  private readonly movementStates = new WeakMap<ObjectModelType, EnemyMovementState>();
 
   async init(): Promise<void> {
     this.enemySprite = await Assets.load<Spritesheet>('assets/game/enemies/enemy.json');
@@ -105,7 +103,7 @@ export class GameEnemyService extends UpdatableService {
     this.updateMovement(enemy, level, true);
   }
 
-  private updateMovement(enemy: Ship, level: number, force = false): void {
+  private updateMovement(enemy: ObjectModelType, level: number, force = false): void {
     const screenWidth = this.application.screen.width;
     const movement = this.getMovementState(enemy);
 
@@ -125,7 +123,7 @@ export class GameEnemyService extends UpdatableService {
     }
   }
 
-  private getMovementState(enemy: Ship): EnemyMovementState {
+  private getMovementState(enemy: ObjectModelType): EnemyMovementState {
     if (!this.movementStates.has(enemy)) {
       this.movementStates.set(enemy, { nextChange: 0 });
     }
@@ -134,8 +132,14 @@ export class GameEnemyService extends UpdatableService {
   }
 
   private getNextHorizontalTarget(currentX: number, screenWidth: number): number {
-    const minDistance = Math.max(screenWidth * MOVEMENT_MIN_DISTANCE_RATIO, MOVEMENT_MIN_DISTANCE_PIXELS);
-    const maxDistance = Math.max(screenWidth * MOVEMENT_MAX_DISTANCE_RATIO, MOVEMENT_MAX_DISTANCE_PIXELS);
+    const minDistance = Math.max(
+      screenWidth * MOVEMENT_MIN_DISTANCE_RATIO,
+      MOVEMENT_MIN_DISTANCE_PIXELS,
+    );
+    const maxDistance = Math.max(
+      screenWidth * MOVEMENT_MAX_DISTANCE_RATIO,
+      MOVEMENT_MAX_DISTANCE_PIXELS,
+    );
     const preferredDirection =
       MOVEMENT_DIRECTIONS[Math.floor(Math.random() * MOVEMENT_DIRECTIONS.length)];
     const travelDistance = minDistance + Math.random() * (maxDistance - minDistance);
@@ -145,7 +149,8 @@ export class GameEnemyService extends UpdatableService {
     const maxX = screenWidth - halfWidth;
 
     if (candidate < minX || candidate > maxX) {
-      candidate = currentX + preferredDirection * MOVEMENT_REVERSE_DIRECTION_MULTIPLIER * travelDistance;
+      candidate =
+        currentX + preferredDirection * MOVEMENT_REVERSE_DIRECTION_MULTIPLIER * travelDistance;
     }
 
     candidate = Math.min(maxX, Math.max(minX, candidate));
@@ -156,7 +161,8 @@ export class GameEnemyService extends UpdatableService {
   private getNextChangeDelay(level: number): number {
     const randomDelay = MOVEMENT_RANDOM_DELAY_MIN + Math.random() * MOVEMENT_RANDOM_DELAY_RANGE;
     const levelAcceleration =
-      Math.min(Math.max(level - 1, 0), MOVEMENT_LEVEL_ACCELERATION_CAP) * MOVEMENT_LEVEL_ACCELERATION;
+      Math.min(Math.max(level - 1, 0), MOVEMENT_LEVEL_ACCELERATION_CAP) *
+      MOVEMENT_LEVEL_ACCELERATION;
 
     return Math.max(MOVEMENT_MIN_DELAY, MOVEMENT_BASE_DELAY + randomDelay - levelAcceleration);
   }


### PR DESCRIPTION
## Summary
- add movement state tracking for enemies so they retarget horizontal positions dynamically
- introduce configurable movement tuning constants and randomized delays for more natural patterns

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ed29d045b4832499151d81d5a27f53