### PR TITLE
Fix coin storage initialization timing

### DIFF
--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -41,6 +41,7 @@ export class GameService {
   readonly storedCoins = signal(0);
   readonly sessionCoins = signal(0);
   readonly coins = computed(() => this.storedCoins() + this.sessionCoins());
+  private readonly coinsInitialized = signal(false);
 
   private readonly collectables = inject(GameCollectableService);
   private readonly landscape = inject(GameLandscapeService);
@@ -84,6 +85,10 @@ export class GameService {
     });
 
     effect(() => {
+      if (!this.coinsInitialized()) {
+        return;
+      }
+
       void this.storage.setCoins(this.coins());
     });
 
@@ -120,6 +125,7 @@ export class GameService {
     await this.shipUpgrades.init();
     const storedCoins = await this.storage.getCoins();
     this.storedCoins.set(storedCoins);
+    this.coinsInitialized.set(true);
 
     this.setup();
 

--- a/src/app/services/game.service.ts
+++ b/src/app/services/game.service.ts
@@ -41,7 +41,6 @@ export class GameService {
   readonly storedCoins = signal(0);
   readonly sessionCoins = signal(0);
   readonly coins = computed(() => this.storedCoins() + this.sessionCoins());
-  private readonly coinsInitialized = signal(false);
 
   private readonly collectables = inject(GameCollectableService);
   private readonly landscape = inject(GameLandscapeService);
@@ -75,20 +74,14 @@ export class GameService {
 
   constructor() {
     effect(() => {
+      this.gameScreen.coins = this.coins();
+
       if (!this.started()) {
         return;
       }
 
       this.gameScreen.kills = this.kills();
       this.gameScreen.level = this.level();
-      this.gameScreen.coins = this.coins();
-    });
-
-    effect(() => {
-      if (!this.coinsInitialized()) {
-        return;
-      }
-
       void this.storage.setCoins(this.coins());
     });
 
@@ -125,7 +118,6 @@ export class GameService {
     await this.shipUpgrades.init();
     const storedCoins = await this.storage.getCoins();
     this.storedCoins.set(storedCoins);
-    this.coinsInitialized.set(true);
 
     this.setup();
 
@@ -310,5 +302,4 @@ export class GameService {
     const sessionCoins = this.sessionCoins();
     this.sessionCoins.set(Math.max(0, sessionCoins - remainingCost));
   }
-
 }


### PR DESCRIPTION
## Summary
- avoid overwriting stored coins before persistence is initialized
- mark coins as initialized after the stored value has been loaded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eea3f60d808324b76752c9a2496a5a