### PR TITLE
chore: update GitHub Actions versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
### Motivation
- Bring workflow action references in `/.github/workflows/deploy.yaml` in line with the repository's desired action versioning policy by updating the `uses` entries.

### Description
- Replace `actions/checkout@v5` with `actions/checkout@v4` and `actions/cache@v1` with `actions/cache@v4` in `/.github/workflows/deploy.yaml` to standardize the action versions used by the deployment job.

### Testing
- No automated tests were run because this is a workflow-only change and does not affect runtime application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b7ecf5bc832480e1d092557f005f)