### PR TITLE
Right-align kill counter under level label

### DIFF
--- a/src/app/services/game-screen.service.ts
+++ b/src/app/services/game-screen.service.ts
@@ -23,6 +23,7 @@ export class GameScreenService extends UpdatableService {
   set kills(value: number) {
     // eslint-disable-next-line no-magic-numbers
     this.points!.text = value.toString().padStart(7, '0');
+    this.points!.x = this.application.screen.width - this.points!.width - HEADER_SIDE_PADDING;
   }
 
   set level(value: number) {
@@ -41,8 +42,8 @@ export class GameScreenService extends UpdatableService {
   }
 
   init(): void {
-    this.points.x = HEADER_SIDE_PADDING;
-    this.points.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * TRIPPLE;
+    this.points.x = this.application.screen.width - this.points.width - HEADER_SIDE_PADDING;
+    this.points.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * DOUBLE;
     this.addToStage(this.points);
 
     const energyBarContainer = new Container();
@@ -57,7 +58,7 @@ export class GameScreenService extends UpdatableService {
     this.addToStage(energyBarContainer);
 
     this.lifesLabel.x = HEADER_SIDE_PADDING;
-    this.lifesLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * DOUBLE;
+    this.lifesLabel.y = HEADER_TOP_PADDING + HEADER_LINE_SPACING * TRIPPLE;
     this.addToStage(this.lifesLabel);
 
     this.levelLabel.x = this.application.screen.width - this.levelLabel.width - HEADER_SIDE_PADDING;


### PR DESCRIPTION
### Motivation
- Place the kill counter on the right side directly beneath the level label to match the requested header layout. 
- Ensure the kill counter stays right-aligned as its text changes so it doesn't drift when the value updates.

### Description
- Updated `src/app/services/game-screen.service.ts` to set `this.points.x` in `init()` to `this.application.screen.width - this.points.width - HEADER_SIDE_PADDING` so the points start at the right edge. 
- Recomputed `points.x` inside the `kills` setter so the kill counter is re-right-aligned after the text changes. 
- Kept the header row ordering by using `HEADER_LINE_SPACING * DOUBLE` for `points.y` and `* TRIPPLE` for the energy bar `lifesLabel.y` so the points appear below the level and the energy bar is shifted down.

### Testing
- Ran the dev server with `npm run start` which completed the build and enabled watch mode successfully. 
- Executed a Playwright script that loaded `http://127.0.0.1:4200/` and saved a screenshot to `artifacts/kill-right-below-level.png` to verify the visual change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980bcfa91a08324b37bab1650206e3f)